### PR TITLE
Set GPG_TTY manually.

### DIFF
--- a/home-manager/programs/fish.nix
+++ b/home-manager/programs/fish.nix
@@ -51,6 +51,7 @@ in {
 
     interactiveShellInit = with lib; ''
       set --universal fish_greeting
+      set --global --export GPG_TTY (${getExe' pkgs.coreutils "tty"})
       source ${pkgs.fzf}/share/fish/vendor_functions.d/fzf_key_bindings.fish
       source ${pkgs.fzf}/share/fish/vendor_conf.d/load-fzf-key-bindings.fish
       ${getExe pkgs.zoxide} init --cmd cd fish | source


### PR DESCRIPTION
Not sure if this is needed, just trying to fix gpg-pinentry crashing the tmux server.

TODO: Test it.