### PR TITLE
Update Git email.

### DIFF
--- a/home-manager/programs/git.nix
+++ b/home-manager/programs/git.nix
@@ -3,7 +3,7 @@
     enable = true;
 
     userName = "Attila Oláh";
-    userEmail = "attila.olah@netstal.com";
+    userEmail = "attila@dorn.haus";
     signing = with config.programs.gpg; {
       signByDefault = enable;
       key = settings.default-key;


### PR DESCRIPTION
The work repos now have the git config set to the work email. Private repos can be signed with the private email.