### PR TITLE
Install rustc.

### DIFF
--- a/home-manager/home/packages.nix
+++ b/home-manager/home/packages.nix
@@ -63,6 +63,7 @@ in {
       lua-language-server
       nil
       pyright
+      rustc
       rust-analyzer
       rustfmt
       stylua


### PR DESCRIPTION
The rust_analyzer LSP plugin seems to want it on the path, and it should be possible to configure a direct path, but for now this will do.