### PR TITLE
Introspection can no longer be forced

### DIFF
--- a/home-manager/wayland/window_manager/hyprland.nix
+++ b/home-manager/wayland/window_manager/hyprland.nix
@@ -175,10 +175,7 @@ in {
       #   use_cpu_buffer = true;
       # };
 
-      opengl = {
-        nvidia_anti_flicker = 0;
-        force_introspection = 2;
-      };
+      opengl.nvidia_anti_flicker = true;
 
       misc.vfr = 0;
 


### PR DESCRIPTION
The option was removed in
https://github.com/hyprwm/Hyprland/commit/ddf180fa304e71b1d6eaa9f2b250a907131b05d9.