### PR TITLE
Remove no-binary option.

### DIFF
--- a/home-manager/programs/uv.nix
+++ b/home-manager/programs/uv.nix
@@ -2,7 +2,6 @@
   programs.uv = {
     enable = true;
     settings = {
-      no-binary = true;
       python-downloads = "never";
       python-preference = "only-system";
     };


### PR DESCRIPTION
Many binaries still work as long as they have no system dependency (e.g. libc), and for edge cases UV can still be started with --no-binary=true or UV_NO_BINARY=1.