### PR TITLE
Configure SSH_AUTH_SOCK for Secretive on macOS

### DIFF
--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -36,6 +36,10 @@
           # Development environment:
           GOPATH = "${homeDirectory}/dev/go";
         }
+        // lib.attrsets.optionalAttrs pkgs.stdenv.isDarwin {
+          # Use Secretive as the SSH agent on MacOS. It is installed via Homebrew or environment.systemPackages.
+          SSH_AUTH_SOCK = "${homeDirectory}/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh";
+        }
         // lib.attrsets.optionalAttrs pkgs.stdenv.isLinux {
           # XDG dirs:
           XDG_DESKTOP_DIR = homeDirectory;

--- a/home-manager/services/gpg_agent.nix
+++ b/home-manager/services/gpg_agent.nix
@@ -2,8 +2,9 @@
 {pkgs, ...}: {
   services.gpg-agent = {
     enable = true;
-    # On MacOS, Secretive is used instead.
-    enableSshSupport = !pkgs.stdEnv.isDarwin;
+    # On MacOS, Secretive is used as the primary SSH agent.
+    # However, GPG-agent is still enabled and can be manually selected, e.g. via host rules.
+    enableSshSupport = true;
     defaultCacheTtl = 8 * 60 * 60; # 8h in secs
     pinentry.package = with pkgs; lib.mkForce pinentry-tty;
     sshKeys = [

--- a/home-manager/services/gpg_agent.nix
+++ b/home-manager/services/gpg_agent.nix
@@ -2,7 +2,8 @@
 {pkgs, ...}: {
   services.gpg-agent = {
     enable = true;
-    enableSshSupport = true;
+    # On MacOS, Secretive is used instead.
+    enableSshSupport = !pkgs.stdEnv.isDarwin;
     defaultCacheTtl = 8 * 60 * 60; # 8h in secs
     pinentry.package = with pkgs; lib.mkForce pinentry-tty;
     sshKeys = [

--- a/hosts/home/users/authorized_keys.nix
+++ b/hosts/home/users/authorized_keys.nix
@@ -2,7 +2,7 @@
   users.users."${user.username}".openssh.authorizedKeys.keys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIiR17IcWh8l3OxxKSt+ODrUMLU98ZoJ+XvcR17iX9/P" # Workstation
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP0Y/37XG4iBs4hHLI88dQQJhtVVal69GRF7HpHT+60J" # Work laptop
-    "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCK3wit0j7rkD4q7DTAij1Swsk6zzCiJZyH6hthB+7Hou49XkEPbt3Obs6541x7LLD4v5XDo0CSm5QGSr2GgqJI=" # MacOS (Secretive)
+    "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDv26UnORlvl+WMrucBQDSwZHzrOjtNvyCThj1PXtI28XhxFRomp/tmIG4Hy4qnOgkQDmqYHYmFRhz/7N/Bq+SM=" # MacOS (Secretive)
     "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC+mtV6yrvijOAmvsstRCYsUSbc8ZI3Np7qY2rWuACNaAnLSRhu5qbL/1EzZgcRFbMKaqRYLy8Tq56PDjck2MTo=" # Android (Terminus)
   ];
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated SSH authentication configuration for macOS users leveraging Secretive for secure key management.
  * Refreshed authorized SSH key entry for macOS.

* **Documentation**
  * Enhanced documentation clarifying GPG-agent functionality and configuration options on macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->