### PR TITLE
Set SSH_AUTH_SOCK on MacOS

### DIFF
--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -38,6 +38,7 @@
         }
         // lib.attrsets.optionalAttrs pkgs.stdenv.isDarwin {
           # Use Secretive as the SSH agent on MacOS. It is installed via Homebrew or environment.systemPackages.
+          # The GPG-agent based socket can still be used by pointing SSH_AUTH_SOCK to GPG_AGENT_INFO.ssh temporarily.
           SSH_AUTH_SOCK = "${homeDirectory}/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh";
         }
         // lib.attrsets.optionalAttrs pkgs.stdenv.isLinux {

--- a/home-manager/services/gpg_agent.nix
+++ b/home-manager/services/gpg_agent.nix
@@ -3,8 +3,7 @@
   services.gpg-agent = {
     enable = true;
     # On MacOS, Secretive is used as the primary SSH agent.
-    # However, GPG-agent is still enabled and can be manually selected, e.g. via host rules.
-    enableSshSupport = true;
+    enableSshSupport = !pkgs.stdenv.isDarwin;
     defaultCacheTtl = 8 * 60 * 60; # 8h in secs
     pinentry.package = with pkgs; lib.mkForce pinentry-tty;
     sshKeys = [


### PR DESCRIPTION
Previously it was overridden by the GPG-agent setting.