### PR TITLE
fix: use loginctl to implicitly lock the screen

### DIFF
--- a/home-manager/wayland/window_manager/hyprland.nix
+++ b/home-manager/wayland/window_manager/hyprland.nix
@@ -82,9 +82,9 @@
       });
       "$LOCK" = lib.getExe (pkgs.writeShellApplication {
         name = "hyprland-shortcut-lock";
-        runtimeInputs = with pkgs; [hyprlock];
+        runtimeInputs = with pkgs; [systemd];
         text = ''
-          exec hyprlock --immediate
+          exec loginctl lock-session
         '';
       });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the window session lock mechanism to use system session locking instead of the previous window manager lock utility, with corresponding dependency adjustments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/attilaolah/os/pull/233)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->