### PR TITLE
Revert "Update dependency anomalyco/opencode to v1.15.5"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,16 +96,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779137822,
-        "narHash": "sha256-HZiqia9QzkJMfRQ6bzFBsiGXNHv1WFLUdwhekE+rXM8=",
+        "lastModified": 1779039880,
+        "narHash": "sha256-aCoajfdfNsEq5YGFwX+YKkC6Bo19f34BbKt3wJ1FNmA=",
         "owner": "anomalyco",
         "repo": "opencode",
-        "rev": "d7a6e1daaf2271bcd0b611fbb27d4956806e475a",
+        "rev": "2b92c5677e830e95d34fc3d5664a69297d2d0b51",
         "type": "github"
       },
       "original": {
         "owner": "anomalyco",
-        "ref": "v1.15.5",
+        "ref": "v1.15.4",
         "repo": "opencode",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
 
     # OpenCode upstream overlay
     opencode = {
-      url = "github:anomalyco/opencode/v1.15.5";
+      url = "github:anomalyco/opencode/v1.15.4";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
Reverts attilaolah/os#245

OpenCode now requires `bun@^1.3.14`, but that version produces broken binaries on NixOS.

- Pending Bun upstream fix: https://github.com/oven-sh/bun/pull/31024
- NixOS tracking bug: https://github.com/oven-sh/bun/issues/31023
- NixOS Bun update PR: https://github.com/NixOS/nixpkgs/pull/519796