### PR TITLE
chore(deps): update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1777988971,
-        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778628724,
-        "narHash": "sha256-VNG6hJ146VEenXcDrB3t6MVnrMx+gtyCWTCDkzOp9Qs=",
+        "lastModified": 1779213149,
+        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a0bbd6b4720da1c9ce7ebf35ff5c41a82db367a",
+        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780666,
-        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Version changes:
[U.]  #01  claude-code                 2.1.137, 2.1.137-fish-completions -> 2.1.141, 2.1.141-fish-completions
[C.]  #02  darwin-system               26.05, 26.05.8c62fba -> 26.05, 26.05.56c666e
[U.]  #03  devenv                      2.1.0, 2.1.0-fish-completions -> 2.1.2, 2.1.2-fish-completions
[U.]  #04  fastfetch                   2.62.1, 2.62.1-fish-completions, 2.62.1-man -> 2.63.1, 2.63.1-fish-completions, 2.63.1-man
[U.]  #05  kubectl                     1.36.0, 1.36.0-fish-completions, 1.36.0-man -> 1.36.1, 1.36.1-fish-completions, 1.36.1-man
[U.]  #06  libgit2                     1.9.2-lib -> 1.9.3-lib
[U.]  #07  nixpkgs-review              3.7.0, 3.7.0-fish-completions -> 3.8.0, 3.8.0-fish-completions
[C.]  #08  nodejs                      22.22.2, 24.14.1, 25.9.0, 25.9.0-fish-completions -> 22.22.3, 24.14.1, 25.9.0, 25.9.0-fish-completions
[C.]  #09  nodejs-slim                 22.22.2, 22.22.2-corepack, 22.22.2-npm, 24.14.1, 24.14.1-corepack, 24.14.1-npm, 25.9.0, 25.9.0-npm -> 22.22.3, 22.22.3-corepack, 22.22.3-npm, 24.14.1, 24.14.1-corepack, 24.14.1-npm, 25.9.0, 25.9.0-npm
[U.]  #10  pnpm                        10.33.4, 10.33.4-fish-completions -> 11.1.1, 11.1.1-fish-completions
[U.]  #11  rclone                      1.74.0, 1.74.0-fish-completions, 1.74.0-man -> 1.74.1, 1.74.1-fish-completions, 1.74.1-man
[U.]  #12  ty                          0.0.34, 0.0.34-fish-completions -> 0.0.36, 0.0.36-fish-completions
[U.]  #13  typescript-language-server  5.1.3, 5.1.3-fish-completions -> 5.2.0, 5.2.0-fish-completions
[U.]  #14  uv                          0.11.11, 0.11.11-fish-completions -> 0.11.14, 0.11.14-fish-completions
Added packages:
[A.]  #1  nix-eval-jobs  2.34.1
```