### PR TITLE
fix: match literal overlay hash assignments

### DIFF
--- a/.github/scripts/update_overlay_hashes.sh
+++ b/.github/scripts/update_overlay_hashes.sh
@@ -41,10 +41,10 @@ set_hash_value() {
       found = 0;
     }
     {
-      if ($0 ~ "^[[:space:]]*" key "[[:space:]]*=[[:space:]]*\"sha256-[A-Za-z0-9+/=]+\"") {
+      if ($0 ~ "^[[:space:]]*" key "[[:space:]]*=[[:space:]]*\"sha256-[A-Za-z0-9+/]{43}=\"") {
         count++;
         if (count == occurrence) {
-          sub(/"sha256-[A-Za-z0-9+/=]+"/, "\"" value "\"");
+          sub(/"sha256-[A-Za-z0-9+/]{43}="/, "\"" value "\"");
           found = 1;
         }
       }

--- a/.github/scripts/update_overlay_hashes.sh
+++ b/.github/scripts/update_overlay_hashes.sh
@@ -41,10 +41,10 @@ set_hash_value() {
       found = 0;
     }
     {
-      if ($0 ~ "^[[:space:]]*" key "[[:space:]]*=[[:space:]]*\"") {
+      if ($0 ~ "^[[:space:]]*" key "[[:space:]]*=[[:space:]]*\"sha256-[A-Za-z0-9+/=]+\"") {
         count++;
         if (count == occurrence) {
-          sub(/"[^"]*"/, "\"" value "\"");
+          sub(/"sha256-[A-Za-z0-9+/=]+"/, "\"" value "\"");
           found = 1;
         }
       }

--- a/.github/workflows/renovate_overlay_hashes.yaml
+++ b/.github/workflows/renovate_overlay_hashes.yaml
@@ -44,7 +44,7 @@ jobs:
         count_hash_literals() {
           local key="$1"
           local overlay="$2"
-          grep -cE "^[[:space:]]*${key}[[:space:]]*=[[:space:]]*\"sha256-[A-Za-z0-9+/=]+\"" "${overlay}" || true
+          grep -cE "^[[:space:]]*${key}[[:space:]]*=[[:space:]]*\"sha256-[A-Za-z0-9+/]{43}=\"" "${overlay}" || true
         }
 
         updated_any='false'

--- a/.github/workflows/renovate_overlay_hashes.yaml
+++ b/.github/workflows/renovate_overlay_hashes.yaml
@@ -41,6 +41,12 @@ jobs:
           exit 0
         fi
 
+        count_hash_literals() {
+          local key="$1"
+          local overlay="$2"
+          grep -cE "^[[:space:]]*${key}[[:space:]]*=[[:space:]]*\"sha256-[A-Za-z0-9+/=]+\"" "${overlay}" || true
+        }
+
         updated_any='false'
         while IFS= read -r overlay; do
           [[ -z "${overlay}" ]] && continue
@@ -48,7 +54,7 @@ jobs:
           package_name="$(basename "${overlay}" .nix | tr '_' '-')"
           mappings=()
 
-          hash_count="$(grep -cE '^[[:space:]]*hash[[:space:]]*=' "${overlay}" || true)"
+          hash_count="$(count_hash_literals 'hash' "${overlay}")"
           if [[ "${hash_count}" -gt 1 ]]; then
             echo "Ambiguous key 'hash' in ${overlay}: found ${hash_count} matches; please disambiguate with explicit occurrences." >&2
             exit 1
@@ -57,7 +63,7 @@ jobs:
             mappings+=("hash=${package_name}-src")
           fi
 
-          npm_deps_hash_count="$(grep -cE '^[[:space:]]*npmDepsHash[[:space:]]*=' "${overlay}" || true)"
+          npm_deps_hash_count="$(count_hash_literals 'npmDepsHash' "${overlay}")"
           if [[ "${npm_deps_hash_count}" -gt 1 ]]; then
             echo "Ambiguous key 'npmDepsHash' in ${overlay}: found ${npm_deps_hash_count} matches; please disambiguate with explicit occurrences." >&2
             exit 1
@@ -66,7 +72,7 @@ jobs:
             mappings+=("npmDepsHash=${package_name}-npm-deps")
           fi
 
-          cargo_hash_count="$(grep -cE '^[[:space:]]*cargoHash[[:space:]]*=' "${overlay}" || true)"
+          cargo_hash_count="$(count_hash_literals 'cargoHash' "${overlay}")"
           if [[ "${cargo_hash_count}" -gt 1 ]]; then
             echo "Ambiguous key 'cargoHash' in ${overlay}: found ${cargo_hash_count} matches; please disambiguate with explicit occurrences." >&2
             exit 1


### PR DESCRIPTION
## Summary
- count only literal sha256 hash assignments in Renovate overlay refresh workflow
- update the hash refresh helper to replace only sha256 literals

## Validation
- bash -n .github/scripts/update_overlay_hashes.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal hash update scripts with refined targeting logic to only match specific hash formats, reducing unintended modifications.
  * Refactored overlay hash refresh workflow to centralize hash-key counting logic, enhancing maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/attilaolah/os/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->