### PR TITLE
chore(deps): upgrade Node.js 25 to 26 and pin llama.cpp

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779213149,
-        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779775000,
+        "narHash": "sha256-L/zHu4oBeXHLea4dNZd7VXLfw1sEC0rpeV9lzkoLZxU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "6ddc8f4cac987262aa16539578f618a3bd818191",
         "type": "github"
       },
       "original": {

--- a/home-manager/home/packages/default.nix
+++ b/home-manager/home/packages/default.nix
@@ -110,7 +110,7 @@
       # NPM packages:
       # NodeJS runtimes & packages
       bun
-      nodejs_25
+      nodejs_26
       pnpm
       prettier
       typescript-language-server

--- a/overlays/llama_cpp.nix
+++ b/overlays/llama_cpp.nix
@@ -2,8 +2,8 @@ final: prev: let
   inherit (builtins) elemAt;
   fetchFromGithubTuple = import ./lib/fetch_from_github_tuple.nix prev;
 
-  github-tags = ["ggml-org/llama.cpp" "9159"]; # extractVersion=^b(?<version>.*)$
-  hash = "sha256-YAlZRlKZwZyZV1kIr2C9MphGIcTI38HIODeUu+vpJw8=";
+  github-tags = ["ggml-org/llama.cpp" "9190"]; # extractVersion=^b(?<version>.*)$
+  hash = "sha256-zajArFzrLUUVsfG1xBttwzwaT9QNlKzDbvSxvof+FMQ=";
   npmDepsHash = "sha256-WaEePrEZ7O/7deP2KJhe0AwiSKYA8HOqETmMHUkmBe0=";
 
   version = elemAt github-tags 1;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Node.js runtime to version 26, replacing the previous version.
  * Updated llama.cpp to the latest available version with the newest features and improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/attilaolah/os/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->