### PR TITLE
fix: remove non-recognised network manager config

### DIFF
--- a/hosts/home/networking.nix
+++ b/hosts/home/networking.nix
@@ -14,10 +14,6 @@ in {
       enable = true;
       # Disallow the ISP's DNS config.
       dns = "systemd-resolved";
-      connectionConfig = {
-        "ipv4.ignore-auto-dns" = "yes";
-        "ipv6.ignore-auto-dns" = "yes";
-      };
     };
     # Google DNS with the hostname for certificate verification.
     nameservers = [


### PR DESCRIPTION
Causes these warnings:

```
Jun 12 13:41:15 home NetworkManager[1793]: <warn>  [1781264475.4260] config: unknown key 'ipv4.ignore-auto-dns' in section [connection] of file '/etc/NetworkManager/NetworkManager.conf'
Jun 12 13:41:15 home NetworkManager[1793]: <warn>  [1781264475.4260] config: unknown key 'ipv6.ignore-auto-dns' in section [connection] of file '/etc/NetworkManager/NetworkManager.conf'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DNS resolution configuration to use systemd-resolved for improved network stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->