### PR TITLE
Add Agent Deck MCP server packages

### DIFF
--- a/home-manager/xdg/config_file/agent_deck/config.toml.nix
+++ b/home-manager/xdg/config_file/agent_deck/config.toml.nix
@@ -68,32 +68,9 @@
       command = lib.getExe pkgs.bitbucket-mcp;
     };
 
-    # TODO: extract the binary and get rid of the Podman wrapper.
     atlassian = {
       description = "Atlassian MCP server";
-      command = lib.getExe pkgs.podman;
-      args = [
-        "run"
-        "-i"
-        "--rm"
-        "-e"
-        "CONFLUENCE_API_TOKEN"
-        "-e"
-        "CONFLUENCE_SPACES_FILTER"
-        "-e"
-        "CONFLUENCE_URL"
-        "-e"
-        "CONFLUENCE_USERNAME"
-        "-e"
-        "JIRA_API_TOKEN"
-        "-e"
-        "JIRA_PROJECTS_FILTER"
-        "-e"
-        "JIRA_URL"
-        "-e"
-        "JIRA_USERNAME"
-        "ghcr.io/sooperset/mcp-atlassian"
-      ];
+      command = lib.getExe pkgs.mcp-atlassian;
     };
 
     flux-operator = {

--- a/home-manager/xdg/config_file/agent_deck/config.toml.nix
+++ b/home-manager/xdg/config_file/agent_deck/config.toml.nix
@@ -68,6 +68,34 @@
       command = lib.getExe pkgs.bitbucket-mcp;
     };
 
+    # TODO: extract the binary and get rid of the Podman wrapper.
+    atlassian = {
+      description = "Atlassian MCP server";
+      command = lib.getExe pkgs.podman;
+      args = [
+        "run"
+        "-i"
+        "--rm"
+        "-e"
+        "CONFLUENCE_API_TOKEN"
+        "-e"
+        "CONFLUENCE_SPACES_FILTER"
+        "-e"
+        "CONFLUENCE_URL"
+        "-e"
+        "CONFLUENCE_USERNAME"
+        "-e"
+        "JIRA_API_TOKEN"
+        "-e"
+        "JIRA_PROJECTS_FILTER"
+        "-e"
+        "JIRA_URL"
+        "-e"
+        "JIRA_USERNAME"
+        "ghcr.io/sooperset/mcp-atlassian"
+      ];
+    };
+
     flux-operator = {
       description = "Flux Operator MCP server";
       command = lib.getExe pkgs.fluxcd-operator-mcp;
@@ -77,6 +105,22 @@
     kubernetes = {
       description = "Kubernetes MCP server";
       command = lib.getExe pkgs.kubernetes-mcp-server;
+    };
+
+    # TODO: extract the binary and get rid of the Podman wrapper.
+    sonarqube = {
+      description = "SonarQube MCP server";
+      command = lib.getExe pkgs.podman;
+      args = [
+        "run"
+        "-i"
+        "--rm"
+        "-e"
+        "SONARQUBE_URL"
+        "-e"
+        "SONARQUBE_TOKEN"
+        "docker.io/mcp/sonarqube"
+      ];
     };
 
     teamcity = {

--- a/home-manager/xdg/config_file/agent_deck/config.toml.nix
+++ b/home-manager/xdg/config_file/agent_deck/config.toml.nix
@@ -107,20 +107,9 @@
       command = lib.getExe pkgs.kubernetes-mcp-server;
     };
 
-    # TODO: extract the binary and get rid of the Podman wrapper.
     sonarqube = {
       description = "SonarQube MCP server";
-      command = lib.getExe pkgs.podman;
-      args = [
-        "run"
-        "-i"
-        "--rm"
-        "-e"
-        "SONARQUBE_URL"
-        "-e"
-        "SONARQUBE_TOKEN"
-        "docker.io/mcp/sonarqube"
-      ];
+      command = lib.getExe pkgs.sonarqube-mcp-server;
     };
 
     teamcity = {

--- a/overlays/agent_deck.nix
+++ b/overlays/agent_deck.nix
@@ -2,7 +2,7 @@ final: prev: let
   inherit (builtins) elemAt;
   fetchFromGithubTuple = import ./lib/fetch_from_github_tuple.nix prev;
 
-  github-tags = ["asheshgoplani/agent-deck" "v1.9.70"];
+  github-tags = ["asheshgoplani/agent-deck" "1.9.70"]; # extractVersion=^v(?<version>.*)$
   hash-src = "sha256-VKpl9PgzpZhDRoSwG0/LH5pJC9HuVbMBBp6Tpa+DRls=";
   hash-vendor = "sha256-teB9HxMGOe5YGW0RGxVOhkDPyczCDdjATRV9Mn9ixDU=";
 
@@ -15,6 +15,7 @@ in {
     src = fetchFromGithubTuple {
       inherit github-tags;
       hash = hash-src;
+      rev = "v${version}";
     };
 
     vendorHash = hash-vendor;

--- a/overlays/markdown_to_confluence.nix
+++ b/overlays/markdown_to_confluence.nix
@@ -1,0 +1,45 @@
+final: prev: let
+  inherit (builtins) elemAt;
+  fetchFromGithubTuple = import ./lib/fetch_from_github_tuple.nix prev;
+  py = prev.python3Packages;
+
+  github-tags = ["hunyadi/md2conf" "0.3.4"];
+  hash-src = "sha256-iUkLbsu/KTzPwBX9+bSwdXsxV6NDe7iTHF+fKHZH7R0=";
+
+  version = elemAt github-tags 1;
+in {
+  markdown-to-confluence = py.buildPythonPackage {
+    pname = "markdown_to_confluence";
+    inherit version;
+    pyproject = true;
+
+    src = fetchFromGithubTuple {
+      inherit github-tags;
+      hash = hash-src;
+    };
+
+    build-system = [py.setuptools];
+    dependencies = with py; [
+      lxml
+      markdown
+      pymdown-extensions
+      pyyaml
+      requests
+    ];
+
+    pythonRemoveDeps = [
+      "types-lxml"
+      "types-markdown"
+      "types-PyYAML"
+      "types-requests"
+    ];
+
+    doCheck = false;
+
+    meta = {
+      description = "Publish Markdown files to Confluence wiki";
+      homepage = "https://github.com/hunyadi/md2conf";
+      license = prev.lib.licenses.mit;
+    };
+  };
+}

--- a/overlays/mcp_atlassian.nix
+++ b/overlays/mcp_atlassian.nix
@@ -5,37 +5,8 @@ final: prev: let
 
   github-tags = ["sooperset/mcp-atlassian" "0.21.1"]; # extractVersion=^v(?<version>.*)$
   hash-src = "sha256-KSkKiseEaDjF0ROPqLf/kO9yA7n8GV9eK96b0VMbDg4=";
-  markdownToConfluenceHash = "sha256-4fnu6z/sQGKVbml/E426wA1HN7Y7qqZptA79bbxlMFw=";
 
   version = elemAt github-tags 1;
-  markdown-to-confluence = py.buildPythonPackage rec {
-    pname = "markdown_to_confluence";
-    version = "0.3.4";
-    pyproject = true;
-
-    src = py.fetchPypi {
-      inherit pname version;
-      hash = markdownToConfluenceHash;
-    };
-
-    build-system = [py.setuptools];
-    dependencies = with py; [
-      lxml
-      markdown
-      pymdown-extensions
-      pyyaml
-      requests
-    ];
-
-    pythonRemoveDeps = [
-      "types-lxml"
-      "types-markdown"
-      "types-PyYAML"
-      "types-requests"
-    ];
-
-    doCheck = false;
-  };
 in {
   mcp-atlassian = py.buildPythonApplication {
     pname = "mcp-atlassian";
@@ -63,7 +34,7 @@ in {
       httpx
       keyring
       markdown
-      markdown-to-confluence
+      prev.markdown-to-confluence
       markdownify
       mcp
       pydantic

--- a/overlays/mcp_atlassian.nix
+++ b/overlays/mcp_atlassian.nix
@@ -1,0 +1,101 @@
+final: prev: let
+  inherit (builtins) elemAt;
+  fetchFromGithubTuple = import ./lib/fetch_from_github_tuple.nix prev;
+  py = prev.python3Packages;
+
+  github-tags = ["sooperset/mcp-atlassian" "0.21.1"]; # extractVersion=^v(?<version>.*)$
+  hash-src = "sha256-KSkKiseEaDjF0ROPqLf/kO9yA7n8GV9eK96b0VMbDg4=";
+  markdownToConfluenceHash = "sha256-4fnu6z/sQGKVbml/E426wA1HN7Y7qqZptA79bbxlMFw=";
+
+  version = elemAt github-tags 1;
+  markdown-to-confluence = py.buildPythonPackage rec {
+    pname = "markdown_to_confluence";
+    version = "0.3.4";
+    pyproject = true;
+
+    src = py.fetchPypi {
+      inherit pname version;
+      hash = markdownToConfluenceHash;
+    };
+
+    build-system = [py.setuptools];
+    dependencies = with py; [
+      lxml
+      markdown
+      pymdown-extensions
+      pyyaml
+      requests
+    ];
+
+    pythonRemoveDeps = [
+      "types-lxml"
+      "types-markdown"
+      "types-PyYAML"
+      "types-requests"
+    ];
+
+    doCheck = false;
+  };
+in {
+  mcp-atlassian = py.buildPythonApplication {
+    pname = "mcp-atlassian";
+    inherit version;
+    pyproject = true;
+
+    src = fetchFromGithubTuple {
+      inherit github-tags;
+      hash = hash-src;
+      rev = "v${version}";
+    };
+
+    build-system = with py; [
+      hatchling
+      uv-dynamic-versioning
+    ];
+
+    dependencies = with py; [
+      atlassian-python-api
+      beautifulsoup4
+      cachetools
+      click
+      fakeredis
+      fastmcp
+      httpx
+      keyring
+      markdown
+      markdown-to-confluence
+      markdownify
+      mcp
+      pydantic
+      python-dateutil
+      python-dotenv
+      requests
+      starlette
+      thefuzz
+      trio
+      truststore
+      unidecode
+      urllib3
+      uvicorn
+    ];
+
+    pythonRelaxDeps = [
+      "fakeredis"
+      "fastmcp"
+    ];
+    pythonRemoveDeps = [
+      "types-cachetools"
+      "types-python-dateutil"
+      "tzdata"
+    ];
+
+    doCheck = false;
+
+    meta = {
+      description = "MCP server for Atlassian products";
+      homepage = "https://github.com/sooperset/mcp-atlassian";
+      license = prev.lib.licenses.mit;
+      mainProgram = "mcp-atlassian";
+    };
+  };
+}

--- a/overlays/sonarqube_mcp_server.nix
+++ b/overlays/sonarqube_mcp_server.nix
@@ -1,0 +1,44 @@
+final: prev: let
+  inherit (builtins) elemAt;
+
+  github-tags = ["SonarSource/sonarqube-mcp-server" "1.18.1.2664"];
+  hash-src = "sha256-IfNnxJWjumoyzQfOnemKK7S49nZZwNlH3qkoZkEMHbM=";
+
+  version = elemAt github-tags 1;
+in {
+  sonarqube-mcp-server = prev.stdenvNoCC.mkDerivation {
+    pname = "sonarqube-mcp-server";
+    inherit version;
+
+    src = prev.fetchurl {
+      url = "https://binaries.sonarsource.com/Distribution/sonarqube-mcp-server/sonarqube-mcp-server-${version}.jar";
+      hash = hash-src;
+    };
+
+    dontUnpack = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm644 $src $out/libexec/sonarqube-mcp-server.jar
+      mkdir -p $out/bin
+      cat > $out/bin/sonarqube-mcp-server <<EOF
+      #!${prev.runtimeShell}
+      set -eu
+      export STORAGE_PATH="\''${STORAGE_PATH:-\''${XDG_STATE_HOME:-\$HOME/.local/state}/sonarqube-mcp-server}"
+      mkdir -p "\$STORAGE_PATH"
+      exec ${prev.jdk21_headless}/bin/java -jar $out/libexec/sonarqube-mcp-server.jar "\$@"
+      EOF
+      chmod +x $out/bin/sonarqube-mcp-server
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "MCP server for SonarQube";
+      homepage = "https://github.com/SonarSource/sonarqube-mcp-server";
+      license = prev.lib.licenses.unfreeRedistributable;
+      mainProgram = "sonarqube-mcp-server";
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add Podman-backed Agent Deck MCP entries for Atlassian and SonarQube
- replace those wrappers with native Nix packages for mcp-atlassian and sonarqube-mcp-server
- split markdown-to-confluence into its own Renovate-trackable overlay
- normalize agent-deck derivation version to avoid v-prefixed package names

## Validation
- nix flake check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Atlassian integration as an MCP server tool
  * Added SonarQube integration as an MCP server tool
  * Added markdown-to-Confluence conversion utility for documentation workflows

* **Chores**
  * Updated agent-deck version handling configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->