### PR TITLE
fix: omit empty MCP arguments in opencode

### DIFF
--- a/overlays/opencode.nix
+++ b/overlays/opencode.nix
@@ -2,9 +2,17 @@ _final: prev: let
   useNixpkgsBunVersion = ''
     sed -i 's/"packageManager": "bun@[^"]*"/"packageManager": "bun@${prev.bun.version}"/' package.json
   '';
+  omitEmptyMcpArguments = ''
+    substituteInPlace packages/opencode/src/mcp/catalog.ts \
+      --replace-fail \
+        'arguments: (args || {}) as Record<string, unknown>,' \
+        'arguments: Object.fromEntries(Object.entries((args || {}) as Record<string, unknown>).filter(([, value]) => value !== "")),'
+  '';
   patchPreBuild = attrs: {preBuild = (attrs.preBuild or "") + useNixpkgsBunVersion;};
+  patchPostPatch = attrs: {postPatch = (attrs.postPatch or "") + omitEmptyMcpArguments;};
 in {
   opencode = prev.opencode.overrideAttrs (oldAttrs:
     {node_modules = oldAttrs.node_modules.overrideAttrs patchPreBuild;}
-    // patchPreBuild oldAttrs);
+    // patchPreBuild oldAttrs
+    // patchPostPatch oldAttrs);
 }


### PR DESCRIPTION
## Summary

Patch the OpenCode overlay so MCP tool calls omit arguments whose value is an empty string. This works around OpenCode forwarding optional MCP string parameters as `""`, which makes strict MCP servers reject calls that should have omitted those parameters.

### Behaviour change

- OpenCode MCP tool calls no longer forward empty-string argument values to MCP servers.
- Optional MCP string parameters that the model/client leaves blank are treated as omitted instead of as explicit empty strings.
- MCP calls such as TeamCity `list_projects` and `list_build_configs` work when OpenCode supplies empty optional string fields.

### Implementation

- Adds a strict `substituteInPlace --replace-fail` in `overlays/opencode.nix` targeting `packages/opencode/src/mcp/catalog.ts`.
- Replaces the direct `(args || {})` forwarding with an `Object.fromEntries(Object.entries(...).filter(...))` expression that drops entries where `value === ""`.
- Uses `--replace-fail` so the overlay fails to build if upstream OpenCode changes the targeted source line.

### Verification

- `alejandra --check overlays/opencode.nix`
- `nix build .#opencode --no-link --print-out-paths`
- Manually reloaded OpenCode and verified TeamCity MCP `list_projects` succeeds with empty optional string args.
- Verified TeamCity MCP `list_build_configs` succeeds with empty optional string args.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument handling in the MCP catalog to prevent empty values from causing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->