### PR TITLE
Update keyboard remappings, fix Homebrew cleanup

### DIFF
--- a/home_manager/xdg/config_file/ghostty/config
+++ b/home_manager/xdg/config_file/ghostty/config
@@ -2,4 +2,6 @@
 font-feature = -liga,-calt
 macos-option-as-alt = true
 keybind = cmd+a=esc:a
+keybind = ctrl+shift+c=copy_to_clipboard
+keybind = ctrl+shift+v=paste_from_clipboard
 theme = Catppuccin Mocha

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -55,7 +55,7 @@
     basic = manipulators: map (mod: mod // {type = "basic";}) manipulators;
   in [
     {
-      description = "Windows/Linux-style text navigation shortcuts";
+      description = "Linux-style text navigation shortcuts";
       manipulators = basic [
         ((any "left_arrow" ["control" "shift"]) // (to "left_arrow" ["option" "shift"]))
         ((any "right_arrow" ["control" "shift"]) // (to "right_arrow" ["option" "shift"]))

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -40,13 +40,15 @@ in {
 
   complex_modifications.rules = let
     dvp = {
-      h = "j";
       f = "y";
+      h = "j";
       j = "c";
       l = "p";
       n = "l";
+      p = "r";
       s = "semicolon";
       t = "k";
+      u = "f";
       w = "comma";
       y = "t";
     };
@@ -106,18 +108,48 @@ in {
     }
     {
       description = "Chrome shortcuts";
-      manipulators = basic (frontmost "com.google.Chrome" [
-        ((any dvp.j ["control" "shift"]) // (to dvp.j ["command" "option"]))
-        ((any dvp.t ["control" "shift"]) // (to dvp.t ["command" "shift"]))
-        ((any dvp.n ["control" "shift"]) // (to dvp.n ["command" "shift"]))
-        ((any dvp.f ["control"]) // (to dvp.f ["command"]))
-        ((any dvp.h ["control"]) // (to dvp.y ["command"]))
-        ((any dvp.t ["control"]) // (to dvp.t ["command"]))
-        ((any dvp.l ["control"]) // (to dvp.l ["command"]))
-        ((any dvp.n ["control"]) // (to dvp.n ["command"]))
-        ((any dvp.s ["control"]) // (to dvp.s ["command"]))
-        ((any dvp.w ["control"]) // (to dvp.w ["command"]))
-      ]);
+      manipulators = basic (frontmost "com.google.Chrome" (
+        (map
+          # Remap Ctrl+Shift+Key to Cmd+Option+Key:
+          (key: ((any dvp.${key} ["control" "shift"]) // (to dvp.${key} ["command" "option"])))
+          [
+            "j" # developer tools
+          ])
+        ++ (map
+          # Remap Ctrl+Shift+Key to Cmd+Shift+Key:
+          (key: ((any dvp.${key} ["control" "shift"]) // (to dvp.${key} ["command" "shift"])))
+          [
+            "t" # most recent tab
+            "n" # new incognito window
+          ])
+        ++ (map
+          # Remap Ctrl+Key to Cmd+Option+Key:
+          (key: ((any dvp.${key} ["control"]) // (to dvp.${key} ["command" "option"])))
+          [
+            "u" # view page source
+          ])
+        ++ (map
+          # Remap Ctrl+Key to Cmd+Shift+Key:
+          (key: ((any dvp.${key} ["control"]) // (to dvp.${key} ["command" "shift"])))
+          [
+            "j" # downloads
+          ])
+        ++ (map
+          # Remap Ctrl+Key to Cmd+Key:
+          (key: ((any dvp.${key} ["control"]) // (to dvp.${key} ["command"])))
+          [
+            "f" # find
+            "l" # jump to the address bar
+            "n" # new window
+            "p" # print
+            "s" # save page as
+            "t" # new tab
+            "w" # close tab
+          ])
+        ++ [
+          ((any dvp.h ["control"]) // (to dvp.y ["command"]))
+        ]
+      ));
     }
   ];
 }

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -44,6 +44,8 @@ in {
     inherit (builtins) attrNames concatMap elemAt head isAttrs replaceStrings;
 
     dvp = {
+      a = "a";
+      c = "i";
       f = "y";
       h = "j";
       j = "c";
@@ -53,7 +55,9 @@ in {
       s = "semicolon";
       t = "k";
       u = "f";
+      v = "period";
       w = "comma";
+      x = "b";
       y = "t";
     };
     das_keyboard_only.conditions = [
@@ -136,7 +140,7 @@ in {
         [["control" "shift"] ["command" "option"] ["j"]]
         [["control"] ["command" "shift"] ["j"]]
         [["control"] ["command" "option"] ["u"]]
-        [["control"] ["command"] ["f" "l" "n" "p" "s" "t" "w" {h = "y";}]]
+        [["control"] ["command"] ["a" "c" "f" "l" "n" "p" "s" "t" "v" "w" "x" {h = "y";}]]
       ]));
     }
   ];

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -52,14 +52,26 @@
       };
     };
     to = key_code: modifiers: {to = [{inherit key_code modifiers;}];};
-    chrome.conditions = [
-      {
-        type = "frontmost_application_if";
-        bundle_identifiers = ["^com\\.google\\.Chrome$"];
-      }
-    ];
     basic = manipulators: map (mod: mod // {type = "basic";}) manipulators;
+    frontmost = bundle_identifier: manipulators:
+      map (mod:
+        mod
+        // {
+          conditions = [
+            {
+              type = "frontmost_application_if";
+              bundle_identifiers = ["^${builtins.replaceStrings ["."] ["\\."] bundle_identifier}$"];
+            }
+          ];
+        })
+      manipulators;
   in [
+    {
+      description = "Option+Tab switches apps";
+      manipulators = basic [
+        ((any "tab" ["option"]) // (to "tab" ["command"]))
+      ];
+    }
     {
       description = "Linux-style text navigation shortcuts";
       manipulators = basic [
@@ -70,18 +82,12 @@
       ];
     }
     {
-      description = "Option+Tab switches apps";
-      manipulators = basic [
-        ((any "tab" ["option"]) // (to "tab" ["command"]))
-      ];
-    }
-    {
-      description = "Chrome tab shortcuts";
-      manipulators = basic [
-        ((any "k" ["control" "shift"]) // (to "k" ["command" "shift"]) // chrome)
-        ((any "k" ["control"]) // (to "k" ["command"]) // chrome)
-        ((any "comma" ["control"]) // (to "comma" ["command"]) // chrome)
-      ];
+      description = "Chrome shortcuts";
+      manipulators = basic (frontmost "com.google.Chrome" [
+        ((any "k" ["control"]) // (to "k" ["command"])) # T
+        ((any "k" ["control" "shift"]) // (to "k" ["command" "shift"])) # T
+        ((any "comma" ["control"]) // (to "comma" ["command"])) # W
+      ]);
     }
   ];
 }

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -52,6 +52,12 @@
       };
     };
     to = key_code: modifiers: {to = [{inherit key_code modifiers;}];};
+    chrome.conditions = [
+      {
+        type = "frontmost_application_if";
+        bundle_identifiers = ["^com\\.google\\.Chrome$"];
+      }
+    ];
     basic = manipulators: map (mod: mod // {type = "basic";}) manipulators;
   in [
     {
@@ -67,6 +73,14 @@
       description = "Option+Tab switches apps";
       manipulators = basic [
         ((any "tab" ["option"]) // (to "tab" ["command"]))
+      ];
+    }
+    {
+      description = "Chrome tab shortcuts";
+      manipulators = basic [
+        ((any "k" ["control" "shift"]) // (to "k" ["command" "shift"]) // chrome)
+        ((any "k" ["control"]) // (to "k" ["command"]) // chrome)
+        ((any "comma" ["control"]) // (to "comma" ["command"]) // chrome)
       ];
     }
   ];

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -67,8 +67,10 @@
       manipulators;
     dvp = {
       h = "j";
+      f = "u";
       j = "c";
       l = "p";
+      n = "b";
       s = "semicolon";
       t = "k";
       w = "comma";
@@ -95,9 +97,11 @@
       manipulators = basic (frontmost "com.google.Chrome" [
         ((any dvp.j ["control" "shift"]) // (to dvp.j ["command" "option"]))
         ((any dvp.t ["control" "shift"]) // (to dvp.t ["command" "shift"]))
+        ((any dvp.f ["control"]) // (to dvp.f ["command"]))
         ((any dvp.h ["control"]) // (to dvp.y ["command"]))
         ((any dvp.t ["control"]) // (to dvp.t ["command"]))
         ((any dvp.l ["control"]) // (to dvp.l ["command"]))
+        ((any dvp.n ["control"]) // (to dvp.n ["command"]))
         ((any dvp.s ["control"]) // (to dvp.s ["command"]))
         ((any dvp.w ["control"]) // (to dvp.w ["command"]))
       ]);

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -65,6 +65,15 @@
           ];
         })
       manipulators;
+    dvp = {
+      h = "j";
+      j = "c";
+      l = "p";
+      s = "semicolon";
+      t = "k";
+      w = "comma";
+      y = "t";
+    };
   in [
     {
       description = "Option+Tab switches apps";
@@ -84,13 +93,13 @@
     {
       description = "Chrome shortcuts";
       manipulators = basic (frontmost "com.google.Chrome" [
-        ((any "c" ["control" "shift"]) // (to "c" ["command" "option"])) # J
-        ((any "k" ["control" "shift"]) // (to "k" ["command" "shift"])) # T
-        ((any "j" ["control"]) // (to "t" ["command"])) # H -> Y
-        ((any "k" ["control"]) // (to "k" ["command"])) # T
-        ((any "p" ["control"]) // (to "p" ["command"])) # L
-        ((any "semicolon" ["control"]) // (to "semicolon" ["command"])) # S
-        ((any "comma" ["control"]) // (to "comma" ["command"])) # W
+        ((any dvp.j ["control" "shift"]) // (to dvp.j ["command" "option"]))
+        ((any dvp.t ["control" "shift"]) // (to dvp.t ["command" "shift"]))
+        ((any dvp.h ["control"]) // (to dvp.y ["command"]))
+        ((any dvp.t ["control"]) // (to dvp.t ["command"]))
+        ((any dvp.l ["control"]) // (to dvp.l ["command"]))
+        ((any dvp.s ["control"]) // (to dvp.s ["command"]))
+        ((any dvp.w ["control"]) // (to dvp.w ["command"]))
       ]);
     }
   ];

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -1,4 +1,6 @@
 let
+  inherit (builtins) attrValues mapAttrs;
+
   # Keyboard identifiers.
   # Any keyboard (in practice, this applies to the built-in keyboard).
   keyboard.is_keyboard = true;
@@ -28,8 +30,8 @@ in {
     ({identifiers = keyboard // das_keyboard;} // (remap "right_option"))
   ];
 
-  simple_modifications = builtins.attrValues (
-    builtins.mapAttrs (from: to: {
+  simple_modifications = attrValues (
+    mapAttrs (from: to: {
       from.key_code = from;
       to = [{key_code = to;}];
     }) {
@@ -39,6 +41,8 @@ in {
   );
 
   complex_modifications.rules = let
+    inherit (builtins) attrNames concatMap elemAt head isAttrs replaceStrings;
+
     dvp = {
       f = "y";
       h = "j";
@@ -74,6 +78,25 @@ in {
     };
     to = key_code: modifiers: {to = [{inherit key_code modifiers;}];};
     basic = manipulators: map (mod: mod // {type = "basic";}) manipulators;
+    shortcuts = concatMap (
+      spec: let
+        from_modifiers = elemAt spec 0;
+        to_modifiers = elemAt spec 1;
+        keys = elemAt spec 2;
+      in
+        map (
+          key: let
+            mapping =
+              if isAttrs key
+              then key
+              else {${key} = key;};
+            from_key = head (attrNames mapping);
+            to_key = mapping.${from_key};
+          in
+            (any dvp.${from_key} from_modifiers) // (to dvp.${to_key} to_modifiers)
+        )
+        keys
+    );
     frontmost = bundle_identifier: manipulators:
       map (mod:
         mod
@@ -81,7 +104,7 @@ in {
           conditions = [
             {
               type = "frontmost_application_if";
-              bundle_identifiers = ["^${builtins.replaceStrings ["."] ["\\."] bundle_identifier}$"];
+              bundle_identifiers = ["^${replaceStrings ["."] ["\\."] bundle_identifier}$"];
             }
           ];
         })
@@ -108,48 +131,13 @@ in {
     }
     {
       description = "Chrome shortcuts";
-      manipulators = basic (frontmost "com.google.Chrome" (
-        (map
-          # Remap Ctrl+Shift+Key to Cmd+Option+Key:
-          (key: ((any dvp.${key} ["control" "shift"]) // (to dvp.${key} ["command" "option"])))
-          [
-            "j" # developer tools
-          ])
-        ++ (map
-          # Remap Ctrl+Shift+Key to Cmd+Shift+Key:
-          (key: ((any dvp.${key} ["control" "shift"]) // (to dvp.${key} ["command" "shift"])))
-          [
-            "t" # most recent tab
-            "n" # new incognito window
-          ])
-        ++ (map
-          # Remap Ctrl+Key to Cmd+Option+Key:
-          (key: ((any dvp.${key} ["control"]) // (to dvp.${key} ["command" "option"])))
-          [
-            "u" # view page source
-          ])
-        ++ (map
-          # Remap Ctrl+Key to Cmd+Shift+Key:
-          (key: ((any dvp.${key} ["control"]) // (to dvp.${key} ["command" "shift"])))
-          [
-            "j" # downloads
-          ])
-        ++ (map
-          # Remap Ctrl+Key to Cmd+Key:
-          (key: ((any dvp.${key} ["control"]) // (to dvp.${key} ["command"])))
-          [
-            "f" # find
-            "l" # jump to the address bar
-            "n" # new window
-            "p" # print
-            "s" # save page as
-            "t" # new tab
-            "w" # close tab
-          ])
-        ++ [
-          ((any dvp.h ["control"]) // (to dvp.y ["command"]))
-        ]
-      ));
+      manipulators = basic (frontmost "com.google.Chrome" (shortcuts [
+        [["control" "shift"] ["command" "shift"] ["t" "n"]]
+        [["control" "shift"] ["command" "option"] ["j"]]
+        [["control"] ["command" "shift"] ["j"]]
+        [["control"] ["command" "option"] ["u"]]
+        [["control"] ["command"] ["f" "l" "n" "p" "s" "t" "w" {h = "y";}]]
+      ]));
     }
   ];
 }

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -84,8 +84,12 @@
     {
       description = "Chrome shortcuts";
       manipulators = basic (frontmost "com.google.Chrome" [
+        ((any "c" ["control" "shift"]) // (to "c" ["command" "option"])) # J
         ((any "k" ["control" "shift"]) // (to "k" ["command" "shift"])) # T
+        ((any "j" ["control"]) // (to "t" ["command"])) # H -> Y
         ((any "k" ["control"]) // (to "k" ["command"])) # T
+        ((any "p" ["control"]) // (to "p" ["command"])) # L
+        ((any "semicolon" ["control"]) // (to "semicolon" ["command"])) # S
         ((any "comma" ["control"]) // (to "comma" ["command"])) # W
       ]);
     }

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -1,17 +1,18 @@
-{
+let
+  # Keyboard identifiers.
+  # Any keyboard (in practice, this applies to the built-in keyboard).
+  keyboard.is_keyboard = true;
+  # Das Keyboard:
+  das_keyboard = {
+    product_id = 320;
+    vendor_id = 9456;
+  };
+in {
   name = "Managed";
   selected = true;
   virtual_hid_keyboard.keyboard_type_v2 = "iso";
 
   devices = let
-    # Keyboard identifiers.
-    # Any keyboard (in practice, this applies to the built-in keyboard).
-    keyboard.is_keyboard = true;
-    # Das Keyboard:
-    das_keyboard = {
-      product_id = 320;
-      vendor_id = 9456;
-    };
     # Keyboard-specific remapping.
     remap = key_code: {
       simple_modifications = [
@@ -38,6 +39,24 @@
   );
 
   complex_modifications.rules = let
+    dvp = {
+      h = "j";
+      f = "y";
+      j = "c";
+      l = "p";
+      n = "l";
+      s = "semicolon";
+      t = "k";
+      w = "comma";
+      y = "t";
+    };
+    das_keyboard_only.conditions = [
+      {
+        type = "device_if";
+        identifiers = [das_keyboard];
+      }
+    ];
+
     any = key_code: mandatory: from key_code mandatory ["any"];
     from = key_code: mandatory: optional: {
       from = {
@@ -65,26 +84,19 @@
           ];
         })
       manipulators;
-    dvp = {
-      h = "j";
-      f = "y";
-      j = "c";
-      l = "p";
-      n = "l";
-      s = "semicolon";
-      t = "k";
-      w = "comma";
-      y = "t";
-    };
   in [
     {
-      description = "Option+Tab switches apps";
+      description = "App and window switching shortcuts";
       manipulators = basic [
+        ((any "tab" ["option" "shift"]) // (to "tab" ["command" "shift"]))
         ((any "tab" ["option"]) // (to "tab" ["command"]))
+        ((any "grave_accent_and_tilde" ["command" "shift"]) // (to "equal_sign" ["command" "option" "shift"]))
+        ((any "grave_accent_and_tilde" ["command"]) // (to "equal_sign" ["command" "option"]))
+        ((any "grave_accent_and_tilde" ["left_option"]) // (to "equal_sign" ["command" "option"]) // das_keyboard_only)
       ];
     }
     {
-      description = "Linux-style text navigation shortcuts";
+      description = "Text navigation shortcuts";
       manipulators = basic [
         ((any "left_arrow" ["control" "shift"]) // (to "left_arrow" ["option" "shift"]))
         ((any "right_arrow" ["control" "shift"]) // (to "right_arrow" ["option" "shift"]))

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -67,10 +67,10 @@
       manipulators;
     dvp = {
       h = "j";
-      f = "u";
+      f = "y";
       j = "c";
       l = "p";
-      n = "b";
+      n = "l";
       s = "semicolon";
       t = "k";
       w = "comma";
@@ -97,6 +97,7 @@
       manipulators = basic (frontmost "com.google.Chrome" [
         ((any dvp.j ["control" "shift"]) // (to dvp.j ["command" "option"]))
         ((any dvp.t ["control" "shift"]) // (to dvp.t ["command" "shift"]))
+        ((any dvp.n ["control" "shift"]) // (to dvp.n ["command" "shift"]))
         ((any dvp.f ["control"]) // (to dvp.f ["command"]))
         ((any dvp.h ["control"]) // (to dvp.y ["command"]))
         ((any dvp.t ["control"]) // (to dvp.t ["command"]))

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -63,5 +63,11 @@
         ((any "right_arrow" ["control"]) // (to "right_arrow" ["option"]))
       ];
     }
+    {
+      description = "Option+Tab switches apps";
+      manipulators = basic [
+        ((any "tab" ["option"]) // (to "tab" ["command"]))
+      ];
+    }
   ];
 }

--- a/home_manager/xdg/config_file/karabiner/profiles/managed.nix
+++ b/home_manager/xdg/config_file/karabiner/profiles/managed.nix
@@ -84,8 +84,8 @@
     {
       description = "Chrome shortcuts";
       manipulators = basic (frontmost "com.google.Chrome" [
-        ((any "k" ["control"]) // (to "k" ["command"])) # T
         ((any "k" ["control" "shift"]) // (to "k" ["command" "shift"])) # T
+        ((any "k" ["control"]) // (to "k" ["command"])) # T
         ((any "comma" ["control"]) // (to "comma" ["command"])) # W
       ]);
     }

--- a/hosts/work/homebrew.nix
+++ b/hosts/work/homebrew.nix
@@ -18,7 +18,6 @@
 
     # GUI applications:
     casks = [
-      "alt-tab"
       "font-jetbrains-mono-nerd-font"
       "ghostty"
       "karabiner-elements"

--- a/hosts/work/homebrew.nix
+++ b/hosts/work/homebrew.nix
@@ -3,8 +3,9 @@
     enable = true;
 
     onActivation = {
-      # All Homebrew packages must be declared below.
-      cleanup = "check";
+      # Uninstall packages not present in this config.
+      # This is intentional. All Homebrew packages must be declared below.
+      cleanup = "zap";
       # Do a full update & upgrade on activation.
       # This is a convenient way to remember to upgrade these packages.
       autoUpdate = true;

--- a/hosts/work/homebrew.nix
+++ b/hosts/work/homebrew.nix
@@ -21,7 +21,6 @@
       "font-jetbrains-mono-nerd-font"
       "ghostty"
       "karabiner-elements"
-      "programmer-dvorak"
       "secretive"
       "tigervnc"
     ];


### PR DESCRIPTION
## Summary by CodeRabbit

* **New Features**
  * Updated terminal clipboard shortcuts to use `Ctrl+Shift+C` and `Ctrl+Shift+V`.
  * Added improved keyboard shortcut handling for app/window switching, text navigation, and browser-specific actions.

* **Bug Fixes**
  * Cleaned up Homebrew-managed apps so undeclared packages are removed automatically during activation, keeping the installed set consistent with the config.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->