### PR TITLE
chore(deps): update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783479733,
-        "narHash": "sha256-d/JatqgG+Pmo+IuCTZfnrEAPWU3fdha48GQeXuFO+bE=",
+        "lastModified": 1783744526,
+        "narHash": "sha256-yYVxW+uIbCx0Nt870fbErQbz+b2+3Gwpppe+JbIU+Co=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cee3f0e7fec85d80c149c7afc29926747f7bd3c2",
+        "rev": "2afec152df4e284d264f8489d16004c264aebf4c",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-FGQ8TfSm9WviNE/fQAWsKs+y4GkX8fU4EScewpw54Y8=",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "lastModified": 1783522502,
+        "narHash": "sha256-nFgG4gPQueCgP8LidXsdI2lYPrSwTcmDl6afcVn7F/U=",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1027867.d407951447dc/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1031299.0bb7ec54c848/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-nFgG4gPQueCgP8LidXsdI2lYPrSwTcmDl6afcVn7F/U=",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
-        "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1031299.0bb7ec54c848/nixexprs.tar.xz"
+        "lastModified": 1783947247,
+        "narHash": "sha256-+n07R2ssDTo7P9+sKzjP3aNnCiy5AEyHi7MaY90BZ3Y=",
+        "owner": "attilaolah",
+        "repo": "nixpkgs",
+        "rev": "f3a88270acc9f5b780be807a6995a83ac47f7737",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",


### PR DESCRIPTION
```
Version changes:
[U.]  #001  alsa-lib                            1.2.15.3 -> 1.2.16
[U.]  #002  alsa-ucm-conf                       1.2.15.3 -> 1.2.16
[U.]  #003  alsa-utils                          1.2.15.2 -> 1.2.16
[U.]  #004  appstream                           1.1.2 -> 1.1.3
[U.]  #005  aws-c-http                          0.10.4 -> 0.11.0
[U.]  #006  aws-c-io                            0.22.0 -> 0.27.2
[U.]  #007  black                               25.1.0-fish-completions -> 26.5.1-fish-completions
[U.]  #008  cargo                               1.95.0, 1.95.0-fish-completions -> 1.96.1, 1.96.1-fish-completions
[U.]  #009  cargo-bootstrap                     1.95.0 -> 1.96.1
[U.]  #010  claude-code                         <none>, 2.1.201 -> 2.1.204, 2.1.204-fish-completions
[U*]  #011  curl                                8.20.0, 8.20.0-bin, 8.20.0-fish-completions, 8.20.0-man -> 8.21.0, 8.21.0-bin, 8.21.0-fish-completions, 8.21.0-man
[U.]  #012  dash                                0.5.13.3 -> 0.5.13.4
[U.]  #013  djvulibre                           3.5.29, 3.5.29-lib -> 3.5.30, 3.5.30-lib
[U*]  #014  docker                              29.6.0 -> 29.6.1
[U.]  #015  docker-compose                      5.3.0, 5.3.0-fish-completions -> 5.3.1, 5.3.1-fish-completions
[U.]  #016  docker-containerd                   29.6.0 -> 29.6.1
[U.]  #017  docker-runc                         29.6.0 -> 29.6.1
[U.]  #018  docker-tini                         29.6.0 -> 29.6.1
[U.]  #019  double-conversion                   3.3.1 -> 3.4.0
[U.]  #020  elfutils                            0.194 -> 0.195
[U.]  #021  expat                               2.8.1, 2.8.1-dev -> 2.8.2, 2.8.2-dev
[U.]  #022  fastfetch                           2.65.1, 2.65.1-fish-completions, 2.65.1-man -> 2.65.2, 2.65.2-fish-completions, 2.65.2-man
[U.]  #023  fastfetch-unwrapped                 2.65.1, 2.65.1-man -> 2.65.2, 2.65.2-man
[C.]  #024  ffmpeg                              7.1.5-data, 7.1.5-lib, 8.1.1-bin, 8.1.1-data, 8.1.1-fish-completions, 8.1.1-lib, 8.1.1-man -> 7.1.5-data, 7.1.5-lib, 8.1.2-bin, 8.1.2-data, 8.1.2-fish-completions, 8.1.2-lib, 8.1.2-man
[U.]  #025  ffmpeg-headless                     8.1.1-data, 8.1.1-lib -> 8.1.2-data, 8.1.2-lib
[U.]  #026  file                                5.47, 5.47-fish-completions, 5.47-man -> 5.48, 5.48-fish-completions, 5.48-man
[U.]  #027  firefox                             152.0.4, 152.0.4-fish-completions -> 152.0.5, 152.0.5-fish-completions
[U.]  #028  firefox-unwrapped                   152.0.4 -> 152.0.5
[U.]  #029  fluidsynth                          2.5.3 -> 2.5.5
[U*]  #030  fontconfig                          2.17.1, 2.17.1-bin, 2.17.1-dev, 2.17.1_fish-completions, 2.17.1-lib -> 2.18.1, 2.18.1-bin, 2.18.1-dev, 2.18.1_fish-completions, 2.18.1-lib
[C*]  #031  fuse                                2.9.9-bin, 2.9.9-man, 3.17.4, 3.17.4-bin, 3.17.4-man -> 2.9.9-bin, 2.9.9-man, 3.18.2, 3.18.2-bin, 3.18.2-man
[U.]  #032  fzf                                 0.73.1, 0.73.1-fish-completions, 0.73.1-man -> 0.74.0, 0.74.0-fish-completions, 0.74.0-man
[U.]  #033  game-music-emu                      0.6.4 -> 0.6.5
[U.]  #034  gflags                              2.2.2 -> 2.3.0
[U.]  #035  giflib                              5.2.2 -> 6.1.3
[U.]  #036  glslang                             16.2.0 -> 16.3.0
[U*]  #037  gnused                              4.9, 4.9-fish-completions x2, 4.9-info -> 4.10, 4.10_fish-completions x2, 4.10-info
[U.]  #038  gperftools                          2.17.2 -> 2.18.1
[U.]  #039  gpgme                               2.0.1 -> 2.1.0
[U.]  #040  graphite2                           1.3.14, 1.3.14-dev -> 1.3.15, 1.3.15-dev
[U.]  #041  graphviz                            12.2.1 -> 14.1.2
[U.]  #042  gssdp                               1.6.4 -> 1.6.5
[U.]  #043  gst-libav                           1.26.11 -> 1.28.4
[U.]  #044  gst-plugins-bad                     1.26.11 -> 1.28.4
[U.]  #045  gst-plugins-base                    1.26.11 -> 1.28.4
[U.]  #046  gst-plugins-good                    1.26.11 x2 -> 1.28.4 x2
[U.]  #047  gst-plugins-ugly                    1.26.11 -> 1.28.4
[U.]  #048  gstreamer                           1.26.11, 1.26.11-bin, 1.26.11-dev -> 1.28.4, 1.28.4-bin, 1.28.4-dev
[U.]  #049  gupnp                               1.6.9 -> 1.6.10
[U.]  #050  hunspell                            1.7.2 -> 1.7.3
[U.]  #051  hwdata                              0.406 -> 0.408
[U.]  #052  hwloc                               2.13.0-lib -> 2.14.0-lib
[U.]  #053  hyphen                              2.8.8 -> 2.8.9
[C.]  #054  icu4c                               74.2, 76.1, 77.1, 78.3, 78.3-dev -> 74.2, 76.1, 76.1-dev, 77.1
[U.]  #055  imagemagick                         7.1.2-24 -> 7.1.2-27
[U*]  #056  iproute2                            7.0.0, 7.0.0_fish-completions -> 7.1.0, 7.1.0_fish-completions
[U.]  #057  jq                                  1.8.1, 1.8.1-bin, 1.8.1-fish-completions, 1.8.1-man -> 1.8.2, 1.8.2-bin, 1.8.2-fish-completions, 1.8.2-man
[U.]  #058  jsoncpp                             1.9.7 -> 1.9.8
[U.]  #059  lcms2                               2.18 -> 2.19.1
[U.]  #060  ldns                                1.9.0 -> 1.9.2
[C.]  #061  lerc                                4.1.0 -> 4.1.0, 4.1.0-dev
[U*]  #062  less                                692, 692-man -> 704, 704-man
[U.]  #063  libapparmor                         4.1.7 -> 5.0.0
[U.]  #064  libarchive                          3.8.7-lib -> 3.8.8-lib
[U.]  #065  libavif                             1.4.1 -> 1.4.2
[U.]  #066  libbacktrace                        0-unstable-2024-03-02 -> 0-unstable-2026-05-03
[U*]  #067  libcap                              2.77, 2.77-doc, 2.77-lib, 2.77-man -> 2.78, 2.78-doc, 2.78-lib, 2.78-man
[U.]  #068  libcbor                             0.13.0 -> 0.14.0
[U.]  #069  libconfig                           1.8 -> 1.8.2
[U.]  #070  libdrm                              2.4.133, 2.4.133-bin, 2.4.133-dev -> 2.4.134, 2.4.134-bin, 2.4.134-dev
[U.]  #071  libdvdcss                           1.4.3 -> 1.5.0
[U.]  #072  libedit                             20251016-3.1 -> 20260508-3.1
[U.]  #073  libei                               1.5.0 -> 1.6.0
[U.]  #074  libgpg-error                        1.59 -> 1.61
[U.]  #075  libheif                             1.23.0-lib -> 1.23.1-lib
[U.]  #076  libidn                              1.43 -> 1.44
[U.]  #077  libjpeg-turbo                       3.1.4 x2, 3.1.4-bin, 3.1.4-dev -> 3.1.4.1 x2, 3.1.4.1-bin, 3.1.4.1-dev
[U.]  #078  libksba                             1.6.7 -> 1.8.0
[U.]  #079  libmd                               1.1.0 -> 1.2.0
[U.]  #080  libmicrohttpd                       1.0.2 -> 1.0.5
[U.]  #081  libmpc                              1.4.0 -> 1.4.1
[U.]  #082  libmpg123                           1.33.4 -> 1.33.5
[U.]  #083  libnice                             0.1.22 -> 0.1.23
[U.]  #084  libopenmpt                          0.8.6 -> 0.8.7
[U.]  #085  libpaper                            1.1.29 -> 2.2.8
[U.]  #086  librsvg                             2.62.1 -> 2.62.3
[U.]  #087  libsodium                           1.0.22-unstable-2026-04-09 -> 1.0.22-unstable-2026-04-16
[U.]  #088  libtpms                             0.10.2 -> 0.10.2-unstable-2026-05-06
[U.]  #089  libusb                              1.0.29, 1.0.29-dev -> 1.0.30, 1.0.30-dev
[U.]  #090  libxi                               1.8.2, 1.8.2-dev -> 1.8.3, 1.8.3-dev
[U.]  #091  libxkbcommon                        1.13.1, 1.13.1-dev -> 1.13.2, 1.13.2-dev
[U.]  #092  libxkbfile                          1.1.3 -> 1.2.0
[U.]  #093  libxmlb                             0.3.25-lib -> 0.3.27-lib
[U.]  #094  lilv                                0.26.4 -> 0.28.0
[U.]  #095  linux-headers                       6.18.7 -> 7.0
[U.]  #096  linux-headers-static                6.18.7 -> 7.0
[U*]  #097  linux-pam                           1.7.1, 1.7.1-doc, 1.7.1-man -> 1.7.2, 1.7.2-doc, 1.7.2-man
[U.]  #098  llhttp                              9.4.1, 9.4.1-dev -> 9.4.2, 9.4.2-dev
[U.]  #099  lttng-ust                           2.14.0 -> 2.15.1
[U*]  #100  lvm2                                2.03.39, 2.03.39-bin, 2.03.39-lib, 2.03.39-man, 2.03.39-scripts -> 2.03.41, 2.03.41-bin, 2.03.41-lib, 2.03.41-man, 2.03.41-scripts
[U.]  #101  md4c                                0.5.2-lib -> 0.5.3-lib
[U.]  #102  mesa-libgbm                         26.0.3 -> 26.1.3
[U.]  #103  moby                                29.6.0 -> 29.6.1
[U.]  #104  mpg123                              1.33.4 -> 1.33.5
[U*]  #105  neovim                              0.12.3 x2, 0.12.3-fish-completions x2 -> 0.12.4 x2, 0.12.4_fish-completions x2
[U.]  #106  neovim-unwrapped                    0.12.3 -> 0.12.4
[U.]  #107  nghttp3                             1.15.0, 1.15.0-dev -> 1.16.0, 1.16.0-dev
[U.]  #108  ngtcp2                              1.22.1, 1.22.1-dev -> 1.23.0, 1.23.0-dev
[U*]  #109  nix                                 2.34.7 x2, 2.34.7-doc, 2.34.7-man -> 2.34.8 x2, 2.34.8-doc, 2.34.8-man
[C.]  #110  nix-cmd                             2.34, 2.34.7 -> 2.34, 2.34.8
[C.]  #111  nix-expr                            2.34, 2.34.7 -> 2.34, 2.34.8
[C.]  #112  nix-fetchers                        2.34, 2.34.7 -> 2.34, 2.34.8
[C.]  #113  nix-flake                           2.34, 2.34.7 -> 2.34, 2.34.8
[C.]  #114  nix-main                            2.34, 2.34.7 -> 2.34, 2.34.8
[U.]  #115  nix-manual                          2.34.7, 2.34.7-man -> 2.34.8, 2.34.8-man
[U.]  #116  nix-nswrapper                       2.34.7 -> 2.34.8
[C.]  #117  nix-store                           2.31.5, 2.34, 2.34.7 -> 2.31.5, 2.34, 2.34.8
[C.]  #118  nix-util                            2.31.5, 2.34, 2.34.7 -> 2.31.5, 2.34, 2.34.8
[U.]  #119  nixfmt                              1.3.1 -> 1.4.0
[U.]  #120  nixos-system-home                   26.11.20260705.d407951 -> 26.11.20260708.0bb7ec5
[C.]  #121  nodejs                              22.23.1, 24.16.0, 26.4.0, 26.4.0-fish-completions -> 22.23.1, 24.18.0, 26.5.0, 26.5.0-fish-completions
[C.]  #122  nodejs-slim                         22.23.1, 22.23.1-corepack, 22.23.1-npm, 24.16.0, 24.16.0-corepack, 24.16.0-npm, 26.4.0, 26.4.0-npm -> 22.23.1, 22.23.1-corepack, 22.23.1-npm, 24.18.0, 24.18.0-corepack, 24.18.0-npm, 26.5.0, 26.5.0-npm
[U.]  #123  nss-cacert                          3.123, 3.123-p11kit -> 3.125, 3.125-p11kit
[U.]  #124  nvim-host-python3                   3.13.13-env -> 3.14.6-env
[U.]  #125  ocl-icd                             2.3.4 -> 2.3.5
[U.]  #126  openssl                             3.6.2, 3.6.2-bin, 3.6.2-dev, 3.6.2-fish-completions, 3.6.2-man -> 3.6.3, 3.6.3-bin, 3.6.3-dev, 3.6.3-fish-completions, 3.6.3-man
[U.]  #127  orc                                 0.4.41 -> 0.4.42
[U.]  #128  perl5.42.0-Config-IniFiles          3.000003 -> 3.002000
[U.]  #129  perl5.42.0-HTML-Parser              3.81 -> 3.85
[U.]  #130  perl5.42.0-HTTP-Message             6.45 -> 7.02
[U.]  #131  perl5.42.0-IO-Compress              2.220 -> 2.221
[U.]  #132  perl5.42.0-XML-LibXML               2.0210 -> 2.0213
[U.]  #133  perl5.42.0-libwww-perl              6.72 -> 6.83
[U*]  #134  pipewire                            1.6.5, 1.6.5-doc, 1.6.5-jack, 1.6.5-man -> 1.6.7, 1.6.7-doc, 1.6.7-jack, 1.6.7-man
[U.]  #135  playwright-test                     1.60.0 -> 1.61.1
[U.]  #136  poppler-glib                        25.10.0 -> 26.06.0
[U.]  #137  poppler-utils                       25.10.0 -> 26.06.0
[C*]  #138  procps                              4.0.6, 4.0.6_fish-completions x2 -> 4.0.6, 4.0.6-doc, 4.0.6-fish-completions, 4.0.6-man
[U.]  #139  protobuf                            34.1 -> 35.1
[U.]  #140  python3                             3.13.13, 3.13.13-env x8, 3.14.4, 3.14.4-env, 3.14.4-env-fish-completions -> 3.14.6, 3.14.6-env x9, 3.14.6-env-fish-completions
[U.]  #141  python3.14-anyio                    4.13.0 -> 4.14.1
[U.]  #142  python3.14-certifi                  2026.01.04 -> 2026.04.22
[U.]  #143  python3.14-click                    8.3.1 -> 8.3.3
[U.]  #144  python3.14-filelock                 3.20.3 -> 3.29.0
[U.]  #145  python3.14-idna                     3.13 -> 3.18
[U.]  #146  python3.14-packaging                26.1 -> 26.2
[U.]  #147  python3.14-polars                   1.40.1 -> 1.41.2
[U.]  #148  python3.14-rich                     14.3.3 -> 15.0.0
[U.]  #149  python3.14-tqdm                     4.67.1 -> 4.67.3
[U.]  #150  python3.14-typer                    0.24.0 -> 0.25.1
[U.]  #151  rustc                               1.95.0, 1.95.0-man -> 1.96.1, 1.96.1-man
[U.]  #152  rustc-bootstrap                     1.95.0 -> 1.96.1
[U.]  #153  rustc-bootstrap-wrapper             1.95.0 -> 1.96.1
[U.]  #154  rustc-wrapper                       1.95.0, 1.95.0-fish-completions, 1.95.0-man -> 1.96.1, 1.96.1-fish-completions, 1.96.1-man
[U.]  #155  rustfmt                             1.95.0, 1.95.0-fish-completions -> 1.96.1, 1.96.1-fish-completions
[U.]  #156  sdl2-compat                         2.32.68 -> 2.32.70
[U.]  #157  socat                               1.8.1.1 -> 1.8.1.3
[U.]  #158  sops                                3.13.1, 3.13.1-fish-completions -> 3.13.2, 3.13.2-fish-completions
[U.]  #159  sord                                0.16.20 -> 0.16.22
[U.]  #160  spidermonkey                        140.9.0 -> 140.11.0
[U.]  #161  sqlite                              3.51.2, 3.51.2-bin, 3.51.2-dev -> 3.53.1, 3.53.1-bin, 3.53.1-dev
[U.]  #162  srt                                 1.5.4 -> 1.5.5
[U.]  #163  svt-av1                             3.1.2 -> 4.1.0
[C*]  #164  systemd                             <none>, 260.2, 260.2-man -> <none>, 261, 261-man
[U.]  #165  systemd-minimal                     260.2 -> 261
[U.]  #166  systemd-minimal-libs                260.2, 260.2-dev -> 261, 261-dev
[U.]  #167  tree-sitter                         0.26.8 -> 0.26.9
[U.]  #168  tree-sitter-c-neovim                0.12.3 -> 0.12.4
[U.]  #169  tree-sitter-lua-neovim              0.12.3 -> 0.12.4
[U.]  #170  tree-sitter-markdown-neovim         0.12.3 -> 0.12.4
[U.]  #171  tree-sitter-markdown_inline-neovim  0.12.3 -> 0.12.4
[U.]  #172  tree-sitter-query-neovim            0.12.3 -> 0.12.4
[U.]  #173  tree-sitter-vim-neovim              0.12.3 -> 0.12.4
[U.]  #174  tree-sitter-vimdoc-neovim           0.12.3 -> 0.12.4
[U*]  #175  util-linux                          2.42-bin, 2.42-fish-completions, 2.42-lastlog, 2.42-lib, 2.42-login, 2.42-man, 2.42-mount, 2.42-swap -> 2.42.2-bin, 2.42.2-fish-completions, 2.42.2-lastlog, 2.42.2-lib, 2.42.2-login, 2.42.2-man, 2.42.2-mount, 2.42.2-swap
[U.]  #176  util-linux-minimal                  2.42-bin, 2.42-lib, 2.42-login, 2.42-mount, 2.42-swap -> 2.42.2-bin, 2.42.2-lib, 2.42.2-login, 2.42.2-mount, 2.42.2-swap
[U.]  #177  uv                                  0.11.25, 0.11.25-fish-completions -> 0.11.26, 0.11.26-fish-completions
[U.]  #178  vulkan-loader                       1.4.341.0 -> 1.4.350.0
[U.]  #179  wayland-protocols                   1.48 -> 1.49
[U*]  #180  which                               2.23, 2.23-info, 2.23-man -> 2.25, 2.25-info, 2.25-man
[U.]  #181  x265                                4.1 -> 4.2
[U*]  #182  xwayland                            24.1.12, 24.1.12_fish-completions x2 -> 24.1.13, 24.1.13-fish-completions x2
[C*]  #183  xz                                  5.8.3, 5.8.3-bin, 5.8.3-doc, 5.8.3-man -> 5.8.3, 5.8.3-bin, 5.8.3-dev, 5.8.3-doc, 5.8.3-man
Added packages:
[A.]  #001  bcachefs-tools                        1.38.8
[A.]  #002  hm_homeao.Xresources                  <none>
[A.]  #003  index.theme                           <none>
[A.]  #004  index.theme-fish-completions          <none>
[A.]  #005  ldacbt                                2.0.72
[A.]  #006  mcpp                                  2.7.2.3
[A.]  #007  omp-checkPhase-hook                   <none>
[A.]  #008  python3.14-aiodns                     4.0.4
[A.]  #009  python3.14-aiofile                    3.8.6
[A.]  #010  python3.14-aiohappyeyeballs           2.7.0
[A.]  #011  python3.14-aiohttp                    3.14.1
[A.]  #012  python3.14-aiosignal                  1.4.0
[A.]  #013  python3.14-annotated-types            0.7.0
[A.]  #014  python3.14-appdirs                    1.4.4
[A.]  #015  python3.14-argcomplete                3.6.3
[A.]  #016  python3.14-atlassian-python-api       4.0.7
[A.]  #017  python3.14-attrs                      26.1.0
[A.]  #018  python3.14-authlib                    1.7.2
[A.]  #019  python3.14-autocommand                2.2.2
[A.]  #020  python3.14-beartype                   0.22.9
[A.]  #021  python3.14-beautifulsoup4             4.14.3
[A.]  #022  python3.14-black                      26.5.1
[A.]  #023  python3.14-brotli                     1.2.0
[A.]  #024  python3.14-build                      1.5.0
[A.]  #025  python3.14-cachecontrol               0.14.4
[A.]  #026  python3.14-cachetools                 6.2.4
[A.]  #027  python3.14-caio                       0.10.1
[A.]  #028  python3.14-cattrs                     25.3.0
[A.]  #029  python3.14-cffi                       2.0.0
[A.]  #030  python3.14-charset-normalizer         3.4.7
[A.]  #031  python3.14-cryptography               49.0.0
[A.]  #032  python3.14-cssselect                  1.3.0
[A.]  #033  python3.14-cyclopts                   4.20.0
[A.]  #034  python3.14-dbus-python                1.4.0
[A.]  #035  python3.14-decorator                  5.2.1
[A.]  #036  python3.14-deprecated                 1.3.1
[A.]  #037  python3.14-distro                     1.9.0
[A.]  #038  python3.14-distutils                  82.0.1
[A.]  #039  python3.14-dnspython                  2.8.0
[A.]  #040  python3.14-docstring-parser           0.17.0
[A.]  #041  python3.14-email-validator            2.3.0
[A.]  #042  python3.14-exceptiongroup             1.3.1
[A.]  #043  python3.14-fakeredis                  2.36.2
[A.]  #044  python3.14-fastmcp                    3.3.1
[A.]  #045  python3.14-fastmcp-slim               3.3.1
[A.]  #046  python3.14-flit-core                  3.12.0
[A.]  #047  python3.14-frozenlist                 1.8.0
[A.]  #048  python3.14-greenlet                   3.3.0
[A.]  #049  python3.14-griffelib                  2.1.0
[A.]  #050  python3.14-gssapi                     1.10.1
[A.]  #051  python3.14-httpx-sse                  0.4.3
[A.]  #052  python3.14-importlib-metadata         9.0.0
[A.]  #053  python3.14-inflect                    7.5.0
[A.]  #054  python3.14-inkex                      1.4.4
[A.]  #055  python3.14-jaraco-classes             3.4.0
[A.]  #056  python3.14-jaraco-collections         5.2.1
[A.]  #057  python3.14-jaraco-context             6.1.0
[A.]  #058  python3.14-jaraco-functools           4.4.0
[A.]  #059  python3.14-jaraco-text                4.0.0
[A.]  #060  python3.14-jeepney                    0.9
[A.]  #061  python3.14-joserfc                    1.6.9
[A.]  #062  python3.14-jsonpath-ng                1.7.0
[A.]  #063  python3.14-jsonref                    1.1.0
[A.]  #064  python3.14-jsonschema                 4.26.0
[A.]  #065  python3.14-jsonschema-path            0.5.0
[A.]  #066  python3.14-jsonschema-specifications  2025.9.1
[A.]  #067  python3.14-keyring                    25.7.0
[A.]  #068  python3.14-krb5                       0.9.0
[A.]  #069  python3.14-levenshtein                0.27.3
[A.]  #070  python3.14-libcst                     1.8.6
[A.]  #071  python3.14-libevdev                   0.13.1
[A.]  #072  python3.14-lxml                       6.1.1
[A.]  #073  python3.14-mako                       1.3.12
[A.]  #074  python3.14-markdown                   3.10.2
[A.]  #075  python3.14-markdown_to_confluence     0.6.1
[A.]  #076  python3.14-markdownify                1.2.2
[A.]  #077  python3.14-markupsafe                 3.0.3
[A.]  #078  python3.14-mcp                        1.27.1
[A.]  #079  python3.14-more-itertools             10.8.0
[A.]  #080  python3.14-moreorless                 0.6.0
[A.]  #081  python3.14-msgpack                    1.1.2
[A.]  #082  python3.14-multidict                  6.7.1
[A.]  #083  python3.14-mypy-extensions            1.1.0
[A.]  #084  python3.14-numpy                      2.5.0
[A.]  #085  python3.14-oauthlib                   3.3.1
[A.]  #086  python3.14-openapi-pydantic           0.5.1
[A.]  #087  python3.14-opentelemetry-api          1.43.0
[A.]  #088  python3.14-orjson                     3.11.9
[A.]  #089  python3.14-outcome                    1.3.0.post0
[A.]  #090  python3.14-pathable                   0.6.0
[A.]  #091  python3.14-pathspec                   1.1.1
[A.]  #092  python3.14-pillow                     12.3.0
[A.]  #093  python3.14-platformdirs               4.9.6
[A.]  #094  python3.14-ply                        3.11
[A.]  #095  python3.14-propcache                  0.5.2
[A.]  #096  python3.14-py-key-value-aio           0.3.0
[A.]  #097  python3.14-py-key-value-shared        0.3.0
[A.]  #098  python3.14-pycairo                    1.29.0
[A.]  #099  python3.14-pycares                    5.0.1
[A.]  #100  python3.14-pycparser                  3.00
[A.]  #101  python3.14-pydantic                   2.13.4
[A.]  #102  python3.14-pydantic-core              2.46.4
[A.]  #103  python3.14-pydantic-settings          2.12.0
[A.]  #104  python3.14-pydbus                     0.6.0
[A.]  #105  python3.14-pygobject                  3.56.3, 3.56.3-dev
[A.]  #106  python3.14-pyjwt                      2.13.0
[A.]  #107  python3.14-pymdown-extensions         10.21.3
[A.]  #108  python3.14-pynvim                     0.6.0
[A.]  #109  python3.14-pyopenssl                  26.3.0, 26.3.0-dev
[A.]  #110  python3.14-pyparsing                  3.3.2
[A.]  #111  python3.14-pyperclip                  1.11.0
[A.]  #112  python3.14-pyproject-hooks            1.2.0
[A.]  #113  python3.14-pyqt5                      5.15.10
[A.]  #114  python3.14-pyqt5-sip                  12.17.0
[A.]  #115  python3.14-pyserial                   3.5
[A.]  #116  python3.14-pyspnego                   0.12.1
[A.]  #117  python3.14-python-dateutil            2.9.0.post0
[A.]  #118  python3.14-python-dotenv              1.2.2
[A.]  #119  python3.14-python-multipart           0.0.30
[A.]  #120  python3.14-pytokens                   0.4.1
[A.]  #121  python3.14-pyudev                     0.24.4
[A.]  #122  python3.14-pyxdg                      0.28
[A.]  #123  python3.14-rapidfuzz                  3.14.5
[A.]  #124  python3.14-redis                      8.0.1
[A.]  #125  python3.14-referencing                0.37.0
[A.]  #126  python3.14-reportlab                  5.0.0
[A.]  #127  python3.14-requests                   2.34.2
[A.]  #128  python3.14-requests-kerberos          0.15.0
[A.]  #129  python3.14-requests-oauthlib          2.0.0
[A.]  #130  python3.14-rich-rst                   2.0.2
[A.]  #131  python3.14-rpds-py                    0.30.0
[A.]  #132  python3.14-scour                      0.38.2
[A.]  #133  python3.14-secretstorage              3.5.0
[A.]  #134  python3.14-setuptools                 82.0.1
[A.]  #135  python3.14-six                        1.17.0
[A.]  #136  python3.14-sniffio                    1.3.1
[A.]  #137  python3.14-sortedcontainers           2.4.0
[A.]  #138  python3.14-soupsieve                  2.8.3
[A.]  #139  python3.14-sse-starlette              3.2.0
[A.]  #140  python3.14-starlette                  1.1.0
[A.]  #141  python3.14-stdlibs                    2026.2.26
[A.]  #142  python3.14-systemd-python             235
[A.]  #143  python3.14-thefuzz                    0.22.1
[A.]  #144  python3.14-tinycss2                   1.5.1
[A.]  #145  python3.14-toml                       0.10.2
[A.]  #146  python3.14-trailrunner                1.4.0
[A.]  #147  python3.14-trio                       0.32.0
[A.]  #148  python3.14-trustme                    1.2.1
[A.]  #149  python3.14-truststore                 0.10.4
[A.]  #150  python3.14-typeguard                  4.5.1
[A.]  #151  python3.14-typing-inspection          0.4.2
[A.]  #152  python3.14-uncalled-for               0.3.2
[A.]  #153  python3.14-unidecode                  1.4.0
[A.]  #154  python3.14-urllib3                    2.7.0
[A.]  #155  python3.14-usort                      1.2.0
[A.]  #156  python3.14-uvicorn                    0.46.0
[A.]  #157  python3.14-watchfiles                 1.1.1
[A.]  #158  python3.14-webencodings               0.5.1
[A.]  #159  python3.14-websockets                 16.0
[A.]  #160  python3.14-wheel                      0.47.0
[A.]  #161  python3.14-wrapt                      1.17.2
[A.]  #162  python3.14-xkcdpass                   1.30.0
[A.]  #163  python3.14-yamllint                   1.37.1
[A.]  #164  python3.14-yarl                       1.24.2
[A.]  #165  python3.14-zipp                       4.0.0
[A.]  #166  python3.14-zstandard                  0.25.0
[A.]  #167  xrdb                                  1.2.2
Removed packages:
[R.]  #001  claude-code-fish-completions          <none>
[R.]  #002  gstreamer-vaapi                       1.26.11
[R.]  #003  ldacBT                                2.0.2.3
[R.]  #004  python3.13-aiodns                     4.0.4
[R.]  #005  python3.13-aiofile                    3.8.6
[R.]  #006  python3.13-aiohappyeyeballs           2.6.1
[R.]  #007  python3.13-aiohttp                    3.13.5
[R.]  #008  python3.13-aiosignal                  1.4.0
[R.]  #009  python3.13-annotated-types            0.7.0
[R.]  #010  python3.13-anyio                      4.13.0
[R.]  #011  python3.13-appdirs                    1.4.4
[R.]  #012  python3.13-argcomplete                3.6.3
[R.]  #013  python3.13-atlassian-python-api       4.0.7
[R.]  #014  python3.13-attrs                      26.1.0
[R.]  #015  python3.13-authlib                    1.7.2
[R.]  #016  python3.13-autocommand                2.2.2
[R.]  #017  python3.13-backports-zstd             1.3.0
[R.]  #018  python3.13-beartype                   0.22.9
[R.]  #019  python3.13-beautifulsoup4             4.14.3
[R.]  #020  python3.13-black                      25.1.0
[R.]  #021  python3.13-brotli                     1.2.0
[R.]  #022  python3.13-build                      1.4.4
[R.]  #023  python3.13-cachecontrol               0.14.4
[R.]  #024  python3.13-cachetools                 6.2.4
[R.]  #025  python3.13-caio                       0.10.1
[R.]  #026  python3.13-cattrs                     25.3.0
[R.]  #027  python3.13-certifi                    2026.01.04
[R.]  #028  python3.13-cffi                       2.0.0
[R.]  #029  python3.13-charset-normalizer         3.4.7
[R.]  #030  python3.13-click                      8.3.1
[R.]  #031  python3.13-cryptography               48.0.0
[R.]  #032  python3.13-cssselect                  1.3.0
[R.]  #033  python3.13-cyclopts                   4.20.0
[R.]  #034  python3.13-dbus-python                1.4.0
[R.]  #035  python3.13-decorator                  5.2.1
[R.]  #036  python3.13-deprecated                 1.3.1
[R.]  #037  python3.13-distro                     1.9.0
[R.]  #038  python3.13-distutils                  80.10.1
[R.]  #039  python3.13-dnspython                  2.8.0
[R.]  #040  python3.13-docstring-parser           0.17.0
[R.]  #041  python3.13-email-validator            2.3.0
[R.]  #042  python3.13-exceptiongroup             1.3.1
[R.]  #043  python3.13-fakeredis                  2.36.2
[R.]  #044  python3.13-fastmcp                    3.3.1
[R.]  #045  python3.13-fastmcp-slim               3.3.1
[R.]  #046  python3.13-filelock                   3.20.3
[R.]  #047  python3.13-flit-core                  3.12.0
[R.]  #048  python3.13-frozenlist                 1.8.0
[R.]  #049  python3.13-greenlet                   3.3.0
[R.]  #050  python3.13-griffelib                  2.1.0
[R.]  #051  python3.13-gssapi                     1.10.1
[R.]  #052  python3.13-h11                        0.16.0
[R.]  #053  python3.13-httpcore                   1.0.9
[R.]  #054  python3.13-httpx                      0.28.1
[R.]  #055  python3.13-httpx-sse                  0.4.3
[R.]  #056  python3.13-idna                       3.13
[R.]  #057  python3.13-importlib-metadata         9.0.0
[R.]  #058  python3.13-inflect                    7.5.0
[R.]  #059  python3.13-inkex                      1.4.4
[R.]  #060  python3.13-jaraco-classes             3.4.0
[R.]  #061  python3.13-jaraco-collections         5.2.1
[R.]  #062  python3.13-jaraco-context             6.1.0
[R.]  #063  python3.13-jaraco-functools           4.4.0
[R.]  #064  python3.13-jaraco-text                4.0.0
[R.]  #065  python3.13-jeepney                    0.9
[R.]  #066  python3.13-jmespath                   1.1.0
[R.]  #067  python3.13-joserfc                    1.6.1
[R.]  #068  python3.13-jsonpath-ng                1.7.0
[R.]  #069  python3.13-jsonref                    1.1.0
[R.]  #070  python3.13-jsonschema                 4.26.0
[R.]  #071  python3.13-jsonschema-path            0.4.6
[R.]  #072  python3.13-jsonschema-specifications  2025.9.1
[R.]  #073  python3.13-keyring                    25.7.0
[R.]  #074  python3.13-krb5                       0.9.0
[R.]  #075  python3.13-levenshtein                0.27.3
[R.]  #076  python3.13-libcst                     1.8.6
[R.]  #077  python3.13-libevdev                   0.13.1
[R.]  #078  python3.13-lxml                       6.0.2
[R.]  #079  python3.13-mako                       1.3.10
[R.]  #080  python3.13-markdown                   3.10.2
[R.]  #081  python3.13-markdown-it-py             4.0.0
[R.]  #082  python3.13-markdown_to_confluence     0.6.1
[R.]  #083  python3.13-markdownify                1.2.2
[R.]  #084  python3.13-markupsafe                 3.0.3
[R.]  #085  python3.13-mcp                        1.27.0
[R.]  #086  python3.13-mdurl                      0.1.2
[R.]  #087  python3.13-more-itertools             10.8.0
[R.]  #088  python3.13-moreorless                 0.6.0
[R.]  #089  python3.13-msgpack                    1.1.2
[R.]  #090  python3.13-multidict                  6.7.1
[R.]  #091  python3.13-mypy-extensions            1.1.0
[R.]  #092  python3.13-numpy                      2.4.4
[R.]  #093  python3.13-oauthlib                   3.3.1
[R.]  #094  python3.13-openapi-pydantic           0.5.1
[R.]  #095  python3.13-opentelemetry-api          1.34.0
[R.]  #096  python3.13-orjson                     3.11.7
[R.]  #097  python3.13-outcome                    1.3.0.post0
[R.]  #098  python3.13-packaging                  26.1
[R.]  #099  python3.13-pathable                   0.5.0
[R.]  #100  python3.13-pathspec                   1.0.4
[R.]  #101  python3.13-pillow                     12.2.0
[R.]  #102  python3.13-platformdirs               4.5.1
[R.]  #103  python3.13-ply                        3.11
[R.]  #104  python3.13-propcache                  0.4.1
[R.]  #105  python3.13-py-key-value-aio           0.3.0
[R.]  #106  python3.13-py-key-value-shared        0.3.0
[R.]  #107  python3.13-pycairo                    1.29.0
[R.]  #108  python3.13-pycares                    5.0.1
[R.]  #109  python3.13-pycparser                  3.00
[R.]  #110  python3.13-pydantic                   2.12.5
[R.]  #111  python3.13-pydantic-core              2.41.5
[R.]  #112  python3.13-pydantic-settings          2.12.0
[R.]  #113  python3.13-pydbus                     0.6.0
[R.]  #114  python3.13-pygments                   2.20.0
[R.]  #115  python3.13-pygobject                  3.56.2, 3.56.2-dev
[R.]  #116  python3.13-pyjwt                      2.13.0
[R.]  #117  python3.13-pymdown-extensions         10.21.3
[R.]  #118  python3.13-pynvim                     0.6.0
[R.]  #119  python3.13-pyopenssl                  26.0.0, 26.0.0-dev
[R.]  #120  python3.13-pyparsing                  3.3.2
[R.]  #121  python3.13-pyperclip                  1.11.0
[R.]  #122  python3.13-pyproject-hooks            1.2.0
[R.]  #123  python3.13-pyqt5                      5.15.10
[R.]  #124  python3.13-pyqt5-sip                  12.17.0
[R.]  #125  python3.13-pyserial                   3.5
[R.]  #126  python3.13-pyspnego                   0.12.1
[R.]  #127  python3.13-python-dateutil            2.9.0.post0
[R.]  #128  python3.13-python-dotenv              1.2.2
[R.]  #129  python3.13-python-multipart           0.0.29
[R.]  #130  python3.13-pyudev                     0.24.4
[R.]  #131  python3.13-pyxdg                      0.28
[R.]  #132  python3.13-pyyaml                     6.0.3
[R.]  #133  python3.13-pyyaml-ft                  8.0.0
[R.]  #134  python3.13-rapidfuzz                  3.14.5
[R.]  #135  python3.13-redis                      7.4.0
[R.]  #136  python3.13-referencing                0.37.0
[R.]  #137  python3.13-reportlab                  5.0.0
[R.]  #138  python3.13-requests                   2.33.1
[R.]  #139  python3.13-requests-kerberos          0.15.0
[R.]  #140  python3.13-requests-oauthlib          2.0.0
[R.]  #141  python3.13-rich                       14.3.3
[R.]  #142  python3.13-rich-rst                   2.0.2
[R.]  #143  python3.13-rpds-py                    0.30.0
[R.]  #144  python3.13-scour                      0.38.2
[R.]  #145  python3.13-secretstorage              3.5.0
[R.]  #146  python3.13-setuptools                 80.10.1
[R.]  #147  python3.13-six                        1.17.0
[R.]  #148  python3.13-sniffio                    1.3.1
[R.]  #149  python3.13-sortedcontainers           2.4.0
[R.]  #150  python3.13-soupsieve                  2.8.3
[R.]  #151  python3.13-sse-starlette              3.2.0
[R.]  #152  python3.13-starlette                  1.1.0
[R.]  #153  python3.13-stdlibs                    2026.2.26
[R.]  #154  python3.13-systemd-python             235
[R.]  #155  python3.13-thefuzz                    0.22.1
[R.]  #156  python3.13-tinycss2                   1.5.1
[R.]  #157  python3.13-toml                       0.10.2
[R.]  #158  python3.13-trailrunner                1.4.0
[R.]  #159  python3.13-trio                       0.32.0
[R.]  #160  python3.13-trustme                    1.2.1
[R.]  #161  python3.13-truststore                 0.10.4
[R.]  #162  python3.13-typeguard                  4.4.4
[R.]  #163  python3.13-typing-extensions          4.15.0
[R.]  #164  python3.13-typing-inspection          0.4.2
[R.]  #165  python3.13-uncalled-for               0.3.2
[R.]  #166  python3.13-unidecode                  1.4.0
[R.]  #167  python3.13-urllib3                    2.6.3
[R.]  #168  python3.13-usort                      1.2.0
[R.]  #169  python3.13-uvicorn                    0.40.0
[R.]  #170  python3.13-watchfiles                 1.1.1
[R.]  #171  python3.13-webencodings               0.5.1
[R.]  #172  python3.13-websockets                 16.0
[R.]  #173  python3.13-wheel                      0.46.1
[R.]  #174  python3.13-wrapt                      1.17.2
[R.]  #175  python3.13-xkcdpass                   1.30.0
[R.]  #176  python3.13-yamllint                   1.37.1
[R.]  #177  python3.13-yarl                       1.23.0
[R.]  #178  python3.13-zipp                       3.23.1
[R.]  #179  python3.13-zstandard                  0.25.0
```
